### PR TITLE
5 Minute Timers | Instant + Tracking Login Rework

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok:1.18.4'
 
 	testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:3.4.6'
 	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
 	testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 
 	testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:3.4.6'
+    testImplementation group: 'com.google.inject.extensions', name: 'guice-testlib', version: '4.1.0'
 	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
 	testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
 }

--- a/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsConfig.java
+++ b/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsConfig.java
@@ -35,6 +35,15 @@ public interface RandomEventAnalyticsConfig extends Config
 		return false;
 	}
 
+
+	@ConfigSection(
+		name = "Notifications",
+		description = "Notifications for Random Event timing & activity",
+		position = 0,
+		closedByDefault = true
+	)
+	String notificationSection = "notifications";
+
 	@ConfigSection(
 		name = "Experimental",
 		description = "Experimental features. May have a negative impact on performance.",

--- a/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsConfig.java
+++ b/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsConfig.java
@@ -18,7 +18,7 @@ public interface RandomEventAnalyticsConfig extends Config
 	@ConfigItem(
 		keyName = "enableEstimation",
 		name = "Enable Estimation",
-		description = "Show the Random Events estimation."
+		description = "Shows a 5 minute sliding timer for events."
 	)
 	default boolean enableEstimation()
 	{
@@ -34,17 +34,6 @@ public interface RandomEventAnalyticsConfig extends Config
 	{
 		return false;
 	}
-
-	@ConfigItem(
-		keyName = "showEventTimeWindow",
-		name = "Show Event Time Window",
-		description = "Shows a 5 minute sliding timer for events.",
-	)
-	default boolean showEventTimeWindow()
-	{
-		return false;
-	}
-
 
 	@ConfigSection(
 		name = "Experimental",

--- a/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsConfig.java
+++ b/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsConfig.java
@@ -13,6 +13,7 @@ public interface RandomEventAnalyticsConfig extends Config
 	String TICKS_SINCE_LAST_RANDOM = "ticksSinceLastRandom";
 	String SECONDS_IN_INSTANCE = "secondsInInstance";
 	String LAST_RANDOM_SPAWN_INSTANT = "lastRandomSpawnInstant";
+	String INTERVALS_SINCE_LAST_RANDOM = "intervalsSinceLastRandom";
 
 	@ConfigItem(
 		keyName = "enableEstimation",
@@ -27,12 +28,23 @@ public interface RandomEventAnalyticsConfig extends Config
 	@ConfigItem(
 		keyName = "enableOverlay",
 		name = "Enable Overlay",
-		description = "Show the Random Events overlay. Enable Estimation must be enabled."
+		description = "Show the Random Events overlay."
 	)
 	default boolean enableOverlay()
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "showEventTimeWindow",
+		name = "Show Event Time Window",
+		description = "Shows a 5 minute sliding timer for events.",
+	)
+	default boolean showEventTimeWindow()
+	{
+		return false;
+	}
+
 
 	@ConfigSection(
 		name = "Experimental",
@@ -41,17 +53,6 @@ public interface RandomEventAnalyticsConfig extends Config
 		closedByDefault = true
 	)
 	String experimentalSection = "experimental";
-
-	@ConfigItem(
-		keyName = "showEventTimeWindow",
-		name = "Show Event Time Window",
-		description = "Shows a 5 minute sliding timer for events.",
-		section = experimentalSection
-	)
-	default boolean showEventTimeWindow()
-	{
-		return false;
-	}
 
 	@ConfigItem(
 		keyName = "showDebug",

--- a/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsConfig.java
+++ b/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsConfig.java
@@ -12,6 +12,7 @@ public interface RandomEventAnalyticsConfig extends Config
 	String SECONDS_SINCE_LAST_RANDOM = "secondsSinceLastRandom";
 	String TICKS_SINCE_LAST_RANDOM = "ticksSinceLastRandom";
 	String SECONDS_IN_INSTANCE = "secondsInInstance";
+	String LAST_RANDOM_SPAWN_INSTANT = "lastRandomSpawnInstant";
 
 	@ConfigItem(
 		keyName = "enableEstimation",
@@ -41,6 +42,16 @@ public interface RandomEventAnalyticsConfig extends Config
 	)
 	String experimentalSection = "experimental";
 
+	@ConfigItem(
+		keyName = "showEventTimeWindow",
+		name = "Show Event Time Window",
+		description = "Shows a 5 minute sliding timer for events.",
+		section = experimentalSection
+	)
+	default boolean showEventTimeWindow()
+	{
+		return false;
+	}
 
 	@ConfigItem(
 		keyName = "showDebug",

--- a/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsOverlay.java
+++ b/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsOverlay.java
@@ -4,7 +4,6 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import javax.inject.Inject;
-import javax.swing.SwingUtilities;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.LineComponent;
@@ -50,6 +49,14 @@ public class RandomEventAnalyticsOverlay extends Overlay
 			.left(estimatedSeconds >= 0 ? TIME_UNTIL_LABEL : OVERESTIMATE_LABEL)
 			.right(RandomEventAnalyticsUtil.formatSeconds(Math.abs(estimatedSeconds)))
 			.build());
+
+		if (config.showEventTimeWindow()) {
+			int closestSpawnTimer = timeTracking.getClosestSpawnTimer();
+			panelComponent.getChildren().add(LineComponent.builder()
+				.left(timeTracking.hasLoggedInLongEnoughForSpawn() ? "Event Spawn Window" : "Waiting for login timer...")
+				.right(RandomEventAnalyticsUtil.formatSeconds(Math.abs(closestSpawnTimer)))
+				.build());
+		}
 
 		if (config.showDebug())
 		{

--- a/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsOverlay.java
+++ b/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsOverlay.java
@@ -39,7 +39,7 @@ public class RandomEventAnalyticsOverlay extends Overlay
 		{
 			int closestSpawnTimer = timeTracking.getNextRandomEventEstimation();
 			panelComponent.getChildren().add(LineComponent.builder()
-				.left(timeTracking.hasLoggedInLongEnoughForSpawn() ? "Event Spawn Window" : "Initial login countdown." +
+				.left(timeTracking.hasLoggedInLongEnoughForSpawn() ? "Random Event Eligible In" : "Initial login countdown." +
 					"..")
 				.right(RandomEventAnalyticsUtil.formatSeconds(Math.abs(closestSpawnTimer)))
 				.build());

--- a/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsOverlay.java
+++ b/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsOverlay.java
@@ -31,29 +31,18 @@ public class RandomEventAnalyticsOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (!config.enableOverlay() || !config.enableEstimation())
+		if (!config.enableOverlay())
 		{
 			return null;
 		}
 		panelComponent.getChildren().clear();
 
-		int estimatedSeconds = timeTracking.getNextRandomEventEstimation();
-
-		// Build overlay title
-		panelComponent.getChildren().add(TitleComponent.builder()
-			.text(TITLE_LABEL)
-			.color(estimatedSeconds >= 0 ? Color.GREEN : Color.RED)
-			.build());
-
-		panelComponent.getChildren().add(LineComponent.builder()
-			.left(estimatedSeconds >= 0 ? TIME_UNTIL_LABEL : OVERESTIMATE_LABEL)
-			.right(RandomEventAnalyticsUtil.formatSeconds(Math.abs(estimatedSeconds)))
-			.build());
-
-		if (config.showEventTimeWindow()) {
-			int closestSpawnTimer = timeTracking.getClosestSpawnTimer();
+		if (config.showEventTimeWindow())
+		{
+			int closestSpawnTimer = timeTracking.getNextRandomEventEstimation();
 			panelComponent.getChildren().add(LineComponent.builder()
-				.left(timeTracking.hasLoggedInLongEnoughForSpawn() ? "Event Spawn Window" : "Waiting for login timer...")
+				.left(timeTracking.hasLoggedInLongEnoughForSpawn() ? "Event Spawn Window" : "Initial login countdown." +
+					"..")
 				.right(RandomEventAnalyticsUtil.formatSeconds(Math.abs(closestSpawnTimer)))
 				.build());
 		}

--- a/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsOverlay.java
+++ b/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsOverlay.java
@@ -1,6 +1,5 @@
 package com.randomEventAnalytics;
 
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import javax.inject.Inject;
@@ -8,7 +7,6 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.PanelComponent;
-import net.runelite.client.ui.overlay.components.TitleComponent;
 
 public class RandomEventAnalyticsOverlay extends Overlay
 {
@@ -17,11 +15,11 @@ public class RandomEventAnalyticsOverlay extends Overlay
 	private static final String TITLE_LABEL = "Random Event";
 	private final RandomEventAnalyticsConfig config;
 	private final PanelComponent panelComponent = new PanelComponent();
-	private final RandomEventAnalyticsTimeTracking timeTracking;
+	private final TimeTracking timeTracking;
 
 	@Inject
 	private RandomEventAnalyticsOverlay(RandomEventAnalyticsConfig config,
-										RandomEventAnalyticsTimeTracking timeTracking)
+										TimeTracking timeTracking)
 	{
 		setPosition(OverlayPosition.ABOVE_CHATBOX_RIGHT);
 		this.config = config;
@@ -37,7 +35,7 @@ public class RandomEventAnalyticsOverlay extends Overlay
 		}
 		panelComponent.getChildren().clear();
 
-		if (config.showEventTimeWindow())
+		if (config.enableEstimation())
 		{
 			int closestSpawnTimer = timeTracking.getNextRandomEventEstimation();
 			panelComponent.getChildren().add(LineComponent.builder()

--- a/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsPanel.java
+++ b/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsPanel.java
@@ -4,14 +4,9 @@ import com.google.inject.Inject;
 import com.randomEventAnalytics.localstorage.RandomEventRecord;
 import java.awt.BorderLayout;
 import java.awt.Color;
-import java.awt.Dimension;
 import java.awt.Font;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
 import java.awt.GridLayout;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
 import javax.swing.JComponent;
@@ -23,7 +18,6 @@ import net.runelite.api.Client;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.PluginPanel;
-import net.runelite.client.ui.SkillColor;
 import net.runelite.client.ui.components.ProgressBar;
 import net.runelite.client.util.ImageUtil;
 
@@ -38,12 +32,12 @@ public class RandomEventAnalyticsPanel extends PluginPanel
 	private final JLabel estimationUntilNext = new JLabel(RandomEventAnalyticsUtil.htmlLabel("Next Event: ", "--:--"));
 	private final JLabel numIntervals = new JLabel();
 	private final JLabel inInstanceIcon = new JLabel("\u26A0");
-	RandomEventAnalyticsTimeTracking timeTracking;
+	TimeTracking timeTracking;
 	RandomEventAnalyticsPlugin plugin;
 
 	@Inject
 	RandomEventAnalyticsPanel(RandomEventAnalyticsPlugin plugin, RandomEventAnalyticsConfig config,
-							  RandomEventAnalyticsTimeTracking timeTracking, Client client)
+							  TimeTracking timeTracking, Client client)
 	{
 		super();
 		this.timeTracking = timeTracking;
@@ -87,7 +81,7 @@ public class RandomEventAnalyticsPanel extends PluginPanel
 		progressWrapper.setBorder(new EmptyBorder(10, 0, 0, 0));
 		progressWrapper.setLayout(new BorderLayout());
 
-		spawnTimeProgressBar.setMaximumValue(RandomEventAnalyticsTimeTracking.SPAWN_INTERVAL_SECONDS);
+		spawnTimeProgressBar.setMaximumValue(TimeTracking.SPAWN_INTERVAL_SECONDS);
 		spawnTimeProgressBar.setBackground(ColorScheme.DARK_GRAY_COLOR);
 		spawnTimeProgressBar.setForeground(ColorScheme.PROGRESS_COMPLETE_COLOR);
 		progressWrapper.add(spawnTimeProgressBar);
@@ -158,7 +152,7 @@ public class RandomEventAnalyticsPanel extends PluginPanel
 			return;
 		}
 
-		spawnTimeProgressBar.setValue(Math.abs(RandomEventAnalyticsTimeTracking.SPAWN_INTERVAL_SECONDS - timeTracking.getNextRandomEventEstimation()));
+		spawnTimeProgressBar.setValue(Math.abs(TimeTracking.SPAWN_INTERVAL_SECONDS - timeTracking.getNextRandomEventEstimation()));
 		numIntervals.setText(String.valueOf(timeTracking.getIntervalsSinceLastRandom()));
 
 		SwingUtilities.invokeLater(() -> {

--- a/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsPanel.java
+++ b/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsPanel.java
@@ -81,20 +81,18 @@ public class RandomEventAnalyticsPanel extends PluginPanel
 		setupInInstanceIcon();
 		estimationPanel.add(inInstanceIcon, BorderLayout.EAST);
 
-		if (config.showEventTimeWindow()) {
-			JPanel progressWrapper = new JPanel();
-			progressWrapper.setBackground(ColorScheme.DARKER_GRAY_COLOR);
-			// https://github.com/runelite/runelite/blob/master/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java#L277
-			progressWrapper.setBorder(new EmptyBorder(10, 0, 0, 0));
-			progressWrapper.setLayout(new BorderLayout());
+		JPanel progressWrapper = new JPanel();
+		progressWrapper.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		// https://github.com/runelite/runelite/blob/master/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java#L277
+		progressWrapper.setBorder(new EmptyBorder(10, 0, 0, 0));
+		progressWrapper.setLayout(new BorderLayout());
 
-			spawnTimeProgressBar.setMaximumValue(RandomEventAnalyticsTimeTracking.SPAWN_INTERVAL_SECONDS);
-			spawnTimeProgressBar.setBackground(ColorScheme.DARK_GRAY_COLOR);
-			spawnTimeProgressBar.setForeground(ColorScheme.PROGRESS_COMPLETE_COLOR);
-			progressWrapper.add(spawnTimeProgressBar);
+		spawnTimeProgressBar.setMaximumValue(RandomEventAnalyticsTimeTracking.SPAWN_INTERVAL_SECONDS);
+		spawnTimeProgressBar.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		spawnTimeProgressBar.setForeground(ColorScheme.PROGRESS_COMPLETE_COLOR);
+		progressWrapper.add(spawnTimeProgressBar);
 
-			estimationPanel.add(progressWrapper, BorderLayout.SOUTH);
-		}
+		estimationPanel.add(progressWrapper, BorderLayout.SOUTH);
 
 		layoutPanel.add(estimationPanel);
 
@@ -160,10 +158,8 @@ public class RandomEventAnalyticsPanel extends PluginPanel
 			return;
 		}
 
-		if (config.showEventTimeWindow()) {
-			spawnTimeProgressBar.setValue(Math.abs(RandomEventAnalyticsTimeTracking.SPAWN_INTERVAL_SECONDS - timeTracking.getNextRandomEventEstimation()));
-			numIntervals.setText(String.valueOf(timeTracking.getIntervalsSinceLastRandom()));
-		}
+		spawnTimeProgressBar.setValue(Math.abs(RandomEventAnalyticsTimeTracking.SPAWN_INTERVAL_SECONDS - timeTracking.getNextRandomEventEstimation()));
+		numIntervals.setText(String.valueOf(timeTracking.getIntervalsSinceLastRandom()));
 
 		SwingUtilities.invokeLater(() -> {
 			int estimatedSeconds = timeTracking.getNextRandomEventEstimation();

--- a/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsPanel.java
+++ b/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsPanel.java
@@ -30,8 +30,6 @@ import net.runelite.client.util.ImageUtil;
 public class RandomEventAnalyticsPanel extends PluginPanel
 {
 	private final ArrayList<RandomEventRecordBox> infoBoxes = new ArrayList<RandomEventRecordBox>();
-
-	private final ProgressBar loginProgressBar = new ProgressBar();
 	private final ProgressBar spawnTimeProgressBar = new ProgressBar();
 	private final JPanel estimationPanel = new JPanel();
 	private final JComponent eventPanel = new JPanel();
@@ -88,25 +86,12 @@ public class RandomEventAnalyticsPanel extends PluginPanel
 			progressWrapper.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 			// https://github.com/runelite/runelite/blob/master/runelite-client/src/main/java/net/runelite/client/plugins/xptracker/XpInfoBox.java#L277
 			progressWrapper.setBorder(new EmptyBorder(10, 0, 0, 0));
-			progressWrapper.setLayout(new GridBagLayout());
-			GridBagConstraints c = new GridBagConstraints();
-			c.fill = GridBagConstraints.HORIZONTAL;
-			c.weightx = 0.5;
-			c.gridx = 0;
-			c.gridy = 0;
+			progressWrapper.setLayout(new BorderLayout());
 
-			loginProgressBar.setMaximumValue(RandomEventAnalyticsTimeTracking.SPAWN_INTERVAL_SECONDS);
-			loginProgressBar.setSize(23, 16);
-			loginProgressBar.setBackground(ColorScheme.MEDIUM_GRAY_COLOR);
-			loginProgressBar.setForeground(Color.BLUE);
-			loginProgressBar.setPreferredSize(new Dimension(23, 16));
-			progressWrapper.add(loginProgressBar, c);
-
-			c.gridx++;
 			spawnTimeProgressBar.setMaximumValue(RandomEventAnalyticsTimeTracking.SPAWN_INTERVAL_SECONDS);
 			spawnTimeProgressBar.setBackground(ColorScheme.DARK_GRAY_COLOR);
 			spawnTimeProgressBar.setForeground(ColorScheme.PROGRESS_COMPLETE_COLOR);
-			progressWrapper.add(spawnTimeProgressBar, c);
+			progressWrapper.add(spawnTimeProgressBar);
 
 			estimationPanel.add(progressWrapper, BorderLayout.SOUTH);
 		}
@@ -176,17 +161,8 @@ public class RandomEventAnalyticsPanel extends PluginPanel
 		}
 
 		if (config.showEventTimeWindow()) {
-			if (!timeTracking.hasLoggedInLongEnoughForSpawn()) {
-				loginProgressBar.setValue(timeTracking.getSecondsSinceLogin());
-				spawnTimeProgressBar.setDimmed(true);
-
-			}
-			else {
-				loginProgressBar.setValue(RandomEventAnalyticsTimeTracking.SPAWN_INTERVAL_SECONDS);
-				spawnTimeProgressBar.setDimmed(false);
-			}
-			spawnTimeProgressBar.setValue(timeTracking.getNextRandomEventEstimation());
-			numIntervals.setText(timeTracking.getCurrentNumIntervals().toString());
+			spawnTimeProgressBar.setValue(Math.abs(RandomEventAnalyticsTimeTracking.SPAWN_INTERVAL_SECONDS - timeTracking.getNextRandomEventEstimation()));
+			numIntervals.setText(String.valueOf(timeTracking.getIntervalsSinceLastRandom()));
 		}
 
 		SwingUtilities.invokeLater(() -> {
@@ -194,6 +170,7 @@ public class RandomEventAnalyticsPanel extends PluginPanel
 			inInstanceIcon.setVisible(client.isInInstancedRegion());
 			estimationUntilNext.setText(RandomEventAnalyticsUtil.htmlLabel("Next Event: ",
 				RandomEventAnalyticsUtil.formatSeconds(Math.abs(estimatedSeconds))));
+			estimationUntilNext.setToolTipText("Intervals: " + timeTracking.getIntervalsSinceLastRandom());
 		});
 	}
 }

--- a/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsPanel.java
+++ b/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsPanel.java
@@ -63,10 +63,11 @@ public class RandomEventAnalyticsPanel extends PluginPanel
 		estimationInfo.setBorder(new EmptyBorder(0, 10, 0, 0));
 
 		estimationUntilNext.setFont(FontManager.getRunescapeSmallFont());
+		numIntervals.setFont(FontManager.getRunescapeSmallFont());
 
 		estimationInfo.add(new JLabel("Random Event Estimation"));
 		estimationInfo.add(estimationUntilNext);
-		estimationInfo.add(numIntervals);
+//		estimationInfo.add(numIntervals);
 
 		estimationPanel.add(new JLabel(new ImageIcon(ImageUtil.loadImageResource(getClass(), "estimation_icon.png"))),
 			BorderLayout.WEST);
@@ -100,7 +101,8 @@ public class RandomEventAnalyticsPanel extends PluginPanel
 		inInstanceIcon.setVisible(false);
 		inInstanceIcon.setFont(new Font(Font.DIALOG, Font.PLAIN, 12));
 		inInstanceIcon.setForeground(Color.RED);
-		inInstanceIcon.setToolTipText("You are currently in an instance where random events cannot spawn.");
+		// Technically they can spawn in houses (I wonder what other instances.)
+		inInstanceIcon.setToolTipText("You are currently in an instance where random events may not spawn.");
 	}
 
 	public void eventRecordBoxUpdated(RandomEventRecordBox randomEventRecordBox, boolean isConfirmed)
@@ -153,7 +155,7 @@ public class RandomEventAnalyticsPanel extends PluginPanel
 		}
 
 		spawnTimeProgressBar.setValue(Math.abs(TimeTracking.SPAWN_INTERVAL_SECONDS - timeTracking.getNextRandomEventEstimation()));
-		numIntervals.setText(String.valueOf(timeTracking.getIntervalsSinceLastRandom()));
+//		numIntervals.setText(String.valueOf(timeTracking.getIntervalsSinceLastRandom()));
 
 		SwingUtilities.invokeLater(() -> {
 			int estimatedSeconds = timeTracking.getNextRandomEventEstimation();

--- a/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsPlugin.java
+++ b/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsPlugin.java
@@ -63,7 +63,7 @@ public class RandomEventAnalyticsPlugin extends Plugin
 	@Inject
 	private RandomEventAnalyticsLocalStorage localStorage;
 	@Inject
-	private RandomEventAnalyticsTimeTracking timeTracking;
+	private TimeTracking timeTracking;
 	@Inject
 	private ClientToolbar clientToolbar;
 	@Inject
@@ -167,8 +167,8 @@ public class RandomEventAnalyticsPlugin extends Plugin
 		else if (state == GameState.LOGIN_SCREEN)
 		{
 			timeTracking.setLoginTime(null);
-			panel.updateEstimation();
 			updateConfig();
+			panel.updateEstimation();
 		}
 	}
 

--- a/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsPlugin.java
+++ b/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsPlugin.java
@@ -11,6 +11,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import javax.inject.Inject;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Actor;
 import net.runelite.api.ChatMessageType;
@@ -73,6 +74,7 @@ public class RandomEventAnalyticsPlugin extends Plugin
 	@Inject
 	private XpTrackerService xpTrackerService;
 
+	@Setter
 	private RandomEventAnalyticsPanel panel;
 	private String profile;
 	private int lastNotificationTick = -RANDOM_EVENT_TIMEOUT;

--- a/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsTimeTracking.java
+++ b/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsTimeTracking.java
@@ -1,18 +1,18 @@
 package com.randomEventAnalytics;
 
 import com.google.inject.Singleton;
-import javax.inject.Inject;
+import com.randomEventAnalytics.localstorage.RandomEventRecord;
+import java.time.Duration;
+import java.time.Instant;
 import lombok.Getter;
 import lombok.Setter;
-import net.runelite.api.Client;
 
 @Singleton
 public class RandomEventAnalyticsTimeTracking
 {
-	private static final int SECONDS_PER_RANDOM_EVENT = 60 * 60;
-	@Inject
-	private Client client;
-	@Getter
+	public static final int SPAWN_INTERVAL_SECONDS = 60 * 5;
+	private static final int SPAWN_INTERVAL_MARGIN_SECONDS = 15;
+
 	@Setter
 	private int secondsSinceLastRandomEvent;
 	@Getter
@@ -20,36 +20,88 @@ public class RandomEventAnalyticsTimeTracking
 	@Getter
 	private int ticksSinceLastRandomEvent;
 
-	public void init(int secondsSinceLastRandomEvent, int secondsInInstance, int ticksSinceLastRandomEvent)
+	@Getter
+	private Instant lastRandomSpawnTime;
+
+	@Getter
+	private Instant loginTime;
+
+	public void init(Instant loginTime, int secondsSinceLastRandomEvent, int secondsInInstance, int ticksSinceLastRandomEvent, Instant lastRandomSpawnTime)
 	{
+		this.loginTime = loginTime;
 		this.secondsSinceLastRandomEvent = secondsSinceLastRandomEvent;
 		this.secondsInInstance = secondsInInstance;
 		this.ticksSinceLastRandomEvent = ticksSinceLastRandomEvent;
+		this.lastRandomSpawnTime = lastRandomSpawnTime;
 	}
 
-	public void incrementSeconds()
-	{
-		secondsSinceLastRandomEvent += 1;
-		if (client.isInInstancedRegion())
-		{
-			secondsInInstance += 1;
+	/**
+	 * Calculates the time since the last random event based on the logged in time
+	 * and the last random spawned time.
+	 *
+	 * Helpful to visualize a timeline:
+	 * LI: Logged In, SP: Spawned Time, LO: Logged Out
+	 *
+	 * LI--SP--LO   LI----LO  LI---SP---LO
+	 *
+	 */
+	public int getTotalSecondsSinceLastRandomEvent() {
+		if (this.lastRandomSpawnTime != null && this.lastRandomSpawnTime.isAfter(this.loginTime)) {
+			return (int) Duration.between(this.lastRandomSpawnTime, Instant.now()).toMillis() / 1000;
 		}
+		return this.secondsSinceLastRandomEvent + this.getSecondsSinceLogin();
 	}
 
-	public void incrementTicks()
+	public void incrementTotalLoggedInTicks()
 	{
 		ticksSinceLastRandomEvent += 1;
 	}
 
-	public int getNextRandomEventEstimation()
-	{
-		return SECONDS_PER_RANDOM_EVENT - secondsSinceLastRandomEvent;
+	public boolean hasLoggedInLongEnoughForSpawn() {
+		return getSecondsSinceLogin() > SPAWN_INTERVAL_SECONDS + SPAWN_INTERVAL_MARGIN_SECONDS;
 	}
 
-	public void reset()
+	public int getSecondsSinceLogin() {
+		if (loginTime == null) return -1;
+		return (int) Duration.between(loginTime, Instant.now()).toMillis() / 1000;
+	}
+
+	public int getClosestSpawnTimer() {
+		int loginTime = getSecondsSinceLogin();
+		if (!hasLoggedInLongEnoughForSpawn()) {
+			// Initial spawn, must wait 5 minutes
+			return SPAWN_INTERVAL_SECONDS - loginTime;
+		}
+
+		int secondsMod = loginTime % SPAWN_INTERVAL_SECONDS;
+		if (secondsMod <= SPAWN_INTERVAL_MARGIN_SECONDS) {
+			// Event should spawn within a 15-second window of 5 minutes.
+			return -secondsMod;
+		}
+
+		// The event will spawn around the next 5-minute period.
+		return SPAWN_INTERVAL_SECONDS - secondsMod;
+	}
+
+	public Integer getCurrentNumIntervals() {
+		return getTotalSecondsSinceLastRandomEvent() / SPAWN_INTERVAL_SECONDS;
+	}
+
+	public int getNextRandomEventEstimation()
 	{
+		return SPAWN_INTERVAL_SECONDS - (getTotalSecondsSinceLastRandomEvent() % SPAWN_INTERVAL_SECONDS);
+	}
+
+	public void setRandomEventSpawned()
+	{
+		lastRandomSpawnTime = Instant.now();
 		secondsInInstance = 0;
 		ticksSinceLastRandomEvent = 0;
 		secondsSinceLastRandomEvent = 0;
+	}
+
+	public void correctStrangePlantSpawn(RandomEventRecord record) {
+		lastRandomSpawnTime = Instant.ofEpochMilli(record.spawnedTime);
+		secondsSinceLastRandomEvent = getTotalSecondsSinceLastRandomEvent();
 	}
 }

--- a/src/main/java/com/randomEventAnalytics/TimeTracking.java
+++ b/src/main/java/com/randomEventAnalytics/TimeTracking.java
@@ -8,12 +8,17 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
+/*
+	Notes:
+		Does everyone get a random 5 minutes after their first login after an
+		update / server restart?
+ */
 @Slf4j
 @Singleton
-public class RandomEventAnalyticsTimeTracking
+public class TimeTracking
 {
 	public static final int SPAWN_INTERVAL_SECONDS = 60 * 5;
-	private static final int SPAWN_INTERVAL_MARGIN_SECONDS = 15;
+	private static final int SPAWN_INTERVAL_MARGIN_SECONDS = 0;
 
 	@Setter
 	private int secondsSinceLastRandomEvent;
@@ -28,7 +33,6 @@ public class RandomEventAnalyticsTimeTracking
 	private int intervalsSinceLastRandom;
 
 	@Getter
-	@Setter
 	private Instant loginTime;
 
 	public void init(Instant loginTime, int secondsSinceLastRandomEvent, int secondsInInstance, int ticksSinceLastRandomEvent, Instant lastRandomSpawnTime, int intervalsSinceLastRandom)
@@ -104,6 +108,13 @@ public class RandomEventAnalyticsTimeTracking
 		intervalsSinceLastRandom = 0;
 	}
 
+	public void setLoginTime(Instant instant) {
+		if (instant == null) {
+			this.intervalsSinceLastRandom = getIntervalsSinceLastRandom();
+		}
+		this.loginTime = instant;
+	}
+
 	public void correctStrangePlantSpawn(RandomEventRecord record) {
 		lastRandomSpawnTime = Instant.ofEpochMilli(record.spawnedTime);
 		secondsSinceLastRandomEvent = getTotalSecondsSinceLastRandomEvent();
@@ -120,7 +131,7 @@ public class RandomEventAnalyticsTimeTracking
 	private void setIntervalsSinceLastRandom(int numIntervals) {
 		if (numIntervals < 0) {
 			// One-time Update: Should only need to be set once per profile config.
-			this.intervalsSinceLastRandom = getTotalSecondsSinceLastRandomEvent() % SPAWN_INTERVAL_SECONDS;
+			this.intervalsSinceLastRandom = getTotalSecondsSinceLastRandomEvent() / SPAWN_INTERVAL_SECONDS;
 		} else {
 			this.intervalsSinceLastRandom = numIntervals;
 		}

--- a/src/main/java/com/randomEventAnalytics/TimeTracking.java
+++ b/src/main/java/com/randomEventAnalytics/TimeTracking.java
@@ -106,6 +106,7 @@ public class TimeTracking
 		ticksSinceLastRandomEvent = 0;
 		secondsSinceLastRandomEvent = 0;
 		intervalsSinceLastRandom = 0;
+		this.setIntervalsSinceLastRandom(0);
 	}
 
 	public void setLoginTime(Instant instant) {

--- a/src/main/java/com/randomEventAnalytics/localstorage/RandomEventAnalyticsLocalStorage.java
+++ b/src/main/java/com/randomEventAnalytics/localstorage/RandomEventAnalyticsLocalStorage.java
@@ -92,6 +92,15 @@ public class RandomEventAnalyticsLocalStorage
 		return data;
 	}
 
+	public synchronized RandomEventRecord getMostRecentRandom() {
+		final ArrayList<RandomEventRecord> data = loadRandomEventRecords();
+		if (data.size() > 0) {
+			return data.get(data.size() - 1);
+		}
+
+		return null;
+	}
+
 	public synchronized boolean renameUsernameFolderToAccountHash(final String username, final long hash)
 	{
 		final File usernameDir = new File(RANDOM_EVENT_RECORD_DIR, username);

--- a/src/main/java/com/randomEventAnalytics/localstorage/RandomEventRecord.java
+++ b/src/main/java/com/randomEventAnalytics/localstorage/RandomEventRecord.java
@@ -1,14 +1,16 @@
 package com.randomEventAnalytics.localstorage;
 
 import com.randomEventAnalytics.RandomEventAnalyticsTimeTracking;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
 public class RandomEventRecord
 {
+	// Random event spawned  time
 	public final long spawnedTime;
+	// Seconds (logged in) since last random event occurred
 	public final int secondsSinceLastRandomEvent;
+	// Ticks (logged in) since last random event occurred
 	public final int ticksSinceLastRandomEvent;
 	public final NpcInfoRecord npcInfoRecord;
 	public final PlayerInfoRecord playerInfoRecord;
@@ -19,7 +21,7 @@ public class RandomEventRecord
 							 NpcInfoRecord npcInfoRecord, PlayerInfoRecord playerInfoRecord, XpInfoRecord xpInfoRecord)
 	{
 		this.spawnedTime = spawnedTime;
-		this.secondsSinceLastRandomEvent = timeTracking.getSecondsSinceLastRandomEvent();
+		this.secondsSinceLastRandomEvent = timeTracking.getTotalSecondsSinceLastRandomEvent();
 		this.ticksSinceLastRandomEvent = timeTracking.getTicksSinceLastRandomEvent();
 		this.secondsInInstance = timeTracking.getSecondsInInstance();
 		this.xpInfoRecord = xpInfoRecord;

--- a/src/main/java/com/randomEventAnalytics/localstorage/RandomEventRecord.java
+++ b/src/main/java/com/randomEventAnalytics/localstorage/RandomEventRecord.java
@@ -1,6 +1,6 @@
 package com.randomEventAnalytics.localstorage;
 
-import com.randomEventAnalytics.RandomEventAnalyticsTimeTracking;
+import com.randomEventAnalytics.TimeTracking;
 import lombok.Data;
 
 @Data
@@ -19,7 +19,7 @@ public class RandomEventRecord
 	public final XpInfoRecord xpInfoRecord;
 	private final int secondsInInstance;
 
-	public RandomEventRecord(long spawnedTime, RandomEventAnalyticsTimeTracking timeTracking,
+	public RandomEventRecord(long spawnedTime, TimeTracking timeTracking,
 							 NpcInfoRecord npcInfoRecord, PlayerInfoRecord playerInfoRecord, XpInfoRecord xpInfoRecord)
 	{
 		this.spawnedTime = spawnedTime;

--- a/src/main/java/com/randomEventAnalytics/localstorage/RandomEventRecord.java
+++ b/src/main/java/com/randomEventAnalytics/localstorage/RandomEventRecord.java
@@ -12,6 +12,8 @@ public class RandomEventRecord
 	public final int secondsSinceLastRandomEvent;
 	// Ticks (logged in) since last random event occurred
 	public final int ticksSinceLastRandomEvent;
+	// Total 5-minute intervals that have passed.
+	public final int intervalsSinceLastRandom;
 	public final NpcInfoRecord npcInfoRecord;
 	public final PlayerInfoRecord playerInfoRecord;
 	public final XpInfoRecord xpInfoRecord;
@@ -24,6 +26,7 @@ public class RandomEventRecord
 		this.secondsSinceLastRandomEvent = timeTracking.getTotalSecondsSinceLastRandomEvent();
 		this.ticksSinceLastRandomEvent = timeTracking.getTicksSinceLastRandomEvent();
 		this.secondsInInstance = timeTracking.getSecondsInInstance();
+		this.intervalsSinceLastRandom = timeTracking.getIntervalsSinceLastRandom();
 		this.xpInfoRecord = xpInfoRecord;
 		this.playerInfoRecord = playerInfoRecord;
 		this.npcInfoRecord = npcInfoRecord;

--- a/src/test/java/com/randomEventAnalytics/RandomEventAnalyticsPluginTest.java
+++ b/src/test/java/com/randomEventAnalytics/RandomEventAnalyticsPluginTest.java
@@ -1,0 +1,140 @@
+package com.randomEventAnalytics;
+
+import com.google.inject.Guice;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import com.randomEventAnalytics.localstorage.RandomEventAnalyticsLocalStorage;
+import javax.inject.Inject;
+import net.runelite.api.Actor;
+import net.runelite.api.Client;
+import net.runelite.api.NPC;
+import net.runelite.api.NpcID;
+import net.runelite.api.Player;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.events.InteractingChanged;
+import net.runelite.client.Notifier;
+import net.runelite.client.chat.ChatMessageManager;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.xptracker.XpTrackerService;
+import net.runelite.client.ui.overlay.OverlayManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.mockito.ArgumentMatchers.any;
+import org.mockito.Mock;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RandomEventAnalyticsPluginTest
+{
+	@Mock
+	@Bind
+	Client client;
+	@Mock
+	@Bind
+	ConfigManager configManager;
+	@Mock
+	@Bind
+	RandomEventAnalyticsConfig config;
+	@Mock
+	@Bind
+	OverlayManager overlayManager;
+	@Mock
+	@Bind
+	RandomEventAnalyticsOverlay overlay;
+	@Mock
+	@Bind
+	RandomEventAnalyticsPanel panel;
+	@Mock
+	@Bind
+	RandomEventAnalyticsLocalStorage localStorage;
+	@Mock
+	@Bind
+	TimeTracking timeTracking;
+	@Mock
+	@Bind
+	ChatMessageManager chatMessageManager;
+	@Mock
+	@Bind
+	XpTrackerService xpTrackerService;
+
+	@Mock
+	@Bind
+	Notifier notifier;
+
+	@Inject
+	RandomEventAnalyticsPlugin plugin;
+
+	@Before
+	public void before() {
+		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+		mockLocalStorage();
+	}
+
+	@Test
+	public void testAddsRandomEventWhenValidNPCInteractionChanged()
+	{
+		doNothing().when(panel).addRandom(any());
+		plugin.setPanel(panel);
+
+		final Player player = getMockedPlayer();
+		when(client.getLocalPlayer()).thenReturn(player);
+		when(client.getTickCount()).thenReturn(10);
+
+		NPC npc1 = getMockedNPC(NpcID.BEE_KEEPER_6747);
+		interactingChanged(npc1, player);
+
+		verify(localStorage, times(1)).addRandomEventRecord(any());
+		verify(panel, times(1)).addRandom(any());
+		verify(timeTracking, times(1)).setRandomEventSpawned();
+	}
+
+	@Test
+	public void testDoesNotAddOtherPlayersRandoms()
+	{
+		final Player player = getMockedPlayer();
+		when(client.getLocalPlayer()).thenReturn(player);
+
+		Player otherPlayer = getMockedPlayer();
+		NPC npc1 = getMockedNPC(NpcID.BEE_KEEPER_6747);
+		interactingChanged(npc1, otherPlayer);
+
+		verify(localStorage, times(0)).addRandomEventRecord(any());
+		verify(panel, times(0)).addRandom(any());
+		verify(timeTracking, times(0)).setRandomEventSpawned();
+	}
+
+	private void mockLocalStorage() {
+		when(localStorage.addRandomEventRecord(any())).thenReturn(true);
+	}
+
+	private NPC getMockedNPC(int npcID) {
+		final NPC npc = mock(NPC.class);
+		when(npc.getWorldLocation()).thenReturn(new WorldPoint(0, 0, 0));
+		when(npc.getLocalLocation()).thenReturn(new LocalPoint(0,0));
+		when(npc.getName()).thenReturn("MockedNPCName");
+		when(npc.getCombatLevel()).thenReturn(1);
+		when(npc.getId()).thenReturn(npcID);
+		return npc;
+	}
+
+	private Player getMockedPlayer() {
+		final Player player = mock(Player.class);
+		when(player.getWorldLocation()).thenReturn(new WorldPoint(0, 0, 0));
+		when(player.getLocalLocation()).thenReturn(new LocalPoint(0,0));
+		when(player.getCombatLevel()).thenReturn(126);
+		return player;
+	}
+
+	private void interactingChanged(final Actor source, final Actor target) {
+		lenient().when(source.getInteracting()).thenReturn(target);
+		plugin.onInteractingChanged(new InteractingChanged(source, target));
+	}
+}

--- a/src/test/java/com/randomEventAnalytics/TimeTrackingTest.java
+++ b/src/test/java/com/randomEventAnalytics/TimeTrackingTest.java
@@ -1,0 +1,30 @@
+package com.randomEventAnalytics;
+
+
+import java.time.Instant;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TimeTrackingTest
+{
+
+	@Test
+	public void testSetsIntervalsForOldProfiles()
+	{
+		int minutesSinceLastSpawn = 60;
+		TimeTracking tracking = new TimeTracking();
+		tracking.init(
+			Instant.now(),
+			minutesSinceLastSpawn * 60,
+			0,
+			0,
+			null,
+			-1
+		);
+
+		Assert.assertEquals(minutesSinceLastSpawn / TimeTracking.SPAWN_INTERVAL_SECONDS, tracking.getIntervalsSinceLastRandom());
+	}
+}


### PR DESCRIPTION
## Reworks how random timing and estimation is handled

Based on discussion in https://github.com/zmanowar/random-event-analytics/issues/3

- Randoms are now based on 5 minute intervals (and the timing is fixed to be accurate to server/login time)
- Adds `interval` tracking & storage
- UI update to show a filling progress bar
  - Overlay has a few small text changes but is largely unchanged.

While this PR initially implements it, I'm sure we'll need more discussion + testing. 🥂 