### PR TITLE
Adding a change to limit how often users are prompted about strange fruits

### DIFF
--- a/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsPlugin.java
+++ b/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsPlugin.java
@@ -277,23 +277,30 @@ public class RandomEventAnalyticsPlugin extends Plugin
 	public void onNpcSpawned(final NpcSpawned event)
 	{
 		final NPC npc = event.getNpc();
-		if (isStrangePlant(npc.getId()))
+		if (!isStrangePlant(npc.getId()))
 		{
-			Player player = client.getLocalPlayer();
-			if (player.getWorldLocation().distanceTo(npc.getWorldLocation()) == STRANGE_PLANT_SPAWN_RADIUS)
-			{
-				/**
-				 * Unfortunately we cannot determine if the Strange Plant belongs to the player
-				 * (See onInteractingChange)
-				 * So we need to add an unconfirmed record (UI only) that allows the player to
-				 * confirm if the plant belongs to them. Only then will it update the records.
-				 */
-				RandomEventRecord record = createRandomEventRecord(npc);
-				panel.addUnconfirmedRandom(record);
-				chatMessageManager.queue(QueuedMessage.builder().type(ChatMessageType.CONSOLE).runeLiteFormattedMessage(PLANT_SPAWNED_NOTIFICATION_MESSAGE).build());
-				notifier.notify(PLANT_SPAWNED_NOTIFICATION_MESSAGE);
-			}
+			return;
 		}
+		Player player = client.getLocalPlayer();
+		if (player.getWorldLocation().distanceTo(npc.getWorldLocation()) != STRANGE_PLANT_SPAWN_RADIUS)
+		{
+			return;
+		}
+		if (!timeTracking.isPossibleTimeForRandomEvent())
+		{
+			// We only want to notify about strange plants when it's possibly the user's random
+			return;
+		}
+		/**
+		 * Unfortunately we cannot determine if the Strange Plant belongs to the player
+		 * (See onInteractingChange)
+		 * So we need to add an unconfirmed record (UI only) that allows the player to
+		 * confirm if the plant belongs to them. Only then will it update the records.
+		 */
+		RandomEventRecord record = createRandomEventRecord(npc);
+		panel.addUnconfirmedRandom(record);
+		chatMessageManager.queue(QueuedMessage.builder().type(ChatMessageType.CONSOLE).runeLiteFormattedMessage(PLANT_SPAWNED_NOTIFICATION_MESSAGE).build());
+		notifier.notify(PLANT_SPAWNED_NOTIFICATION_MESSAGE);
 	}
 
 	@Subscribe

--- a/src/main/java/com/randomEventAnalytics/TimeTracking.java
+++ b/src/main/java/com/randomEventAnalytics/TimeTracking.java
@@ -21,6 +21,7 @@ public class TimeTracking
 	public static final int SPAWN_INTERVAL_SECONDS = 60 * 5;
 	private static final int SPAWN_INTERVAL_MARGIN_SECONDS = 0;
 	private static final int SPAWN_INTERVAL_TIMEFRAME_SECONDS = 15;
+	public static final int SECONDS_IN_AN_HOUR = 60 /*seconds in a minute*/ * 60 /*minutes in an hour*/;
 
 	private int sessionTicks;
 
@@ -101,24 +102,33 @@ public class TimeTracking
 		return SPAWN_INTERVAL_SECONDS - secondsMod;
 	}
 
+	private boolean isInsideRandomEventWindow()
+	{
+		int loginTime = getSecondsSinceLogin();
+		int secondsMod = loginTime % SPAWN_INTERVAL_SECONDS;
+		// If we're within 15 seconds of an event window, it's considered a possible time.
+		return secondsMod <= SPAWN_INTERVAL_TIMEFRAME_SECONDS || secondsMod >= SPAWN_INTERVAL_SECONDS - SPAWN_INTERVAL_TIMEFRAME_SECONDS;
+	}
+
 	public boolean isPossibleTimeForRandomEvent()
 	{
+		if (lastRandomSpawnInstant == null)
+		{
+			return isInsideRandomEventWindow();
+		}
+
 		if (!hasLoggedInLongEnoughForSpawn())
 		{
 			return false;
 		}
 
-		int secondsInAnHour = 60 /*seconds in a minute*/ * 60 /*minutes in an hour*/;
-		if (getTotalSecondsSinceLastRandomEvent() <  secondsInAnHour)
+		if (getTotalSecondsSinceLastRandomEvent() <  SECONDS_IN_AN_HOUR)
 		{
 			// There's a minimum of an hour between random events.
 			return false;
 		}
 
-		int loginTime = getSecondsSinceLogin();
-		int secondsMod = loginTime % SPAWN_INTERVAL_SECONDS;
-		// If we're within 15 seconds of an event window, it's considered a possible time.
-		return secondsMod <= SPAWN_INTERVAL_TIMEFRAME_SECONDS || secondsMod >= SPAWN_INTERVAL_SECONDS - SPAWN_INTERVAL_TIMEFRAME_SECONDS;
+		return isInsideRandomEventWindow();
 	}
 
 	public void setRandomEventSpawned()

--- a/src/main/java/com/randomEventAnalytics/TimeTracking.java
+++ b/src/main/java/com/randomEventAnalytics/TimeTracking.java
@@ -20,6 +20,7 @@ public class TimeTracking
 {
 	public static final int SPAWN_INTERVAL_SECONDS = 60 * 5;
 	private static final int SPAWN_INTERVAL_MARGIN_SECONDS = 0;
+	private static final int SPAWN_INTERVAL_TIMEFRAME_SECONDS = 15;
 
 	private int sessionTicks;
 
@@ -98,6 +99,26 @@ public class TimeTracking
 
 		// The event will spawn around the next 5-minute period.
 		return SPAWN_INTERVAL_SECONDS - secondsMod;
+	}
+
+	public boolean isPossibleTimeForRandomEvent()
+	{
+		if (!hasLoggedInLongEnoughForSpawn())
+		{
+			return false;
+		}
+
+		int secondsInAnHour = 60 /*seconds in a minute*/ * 60 /*minutes in an hour*/;
+		if (getTotalSecondsSinceLastRandomEvent() <  secondsInAnHour)
+		{
+			// There's a minimum of an hour between random events.
+			return false;
+		}
+
+		int loginTime = getSecondsSinceLogin();
+		int secondsMod = loginTime % SPAWN_INTERVAL_SECONDS;
+		// If we're within 15 seconds of an event window, it's considered a possible time.
+		return secondsMod <= SPAWN_INTERVAL_TIMEFRAME_SECONDS || secondsMod >= SPAWN_INTERVAL_SECONDS - SPAWN_INTERVAL_TIMEFRAME_SECONDS;
 	}
 
 	public void setRandomEventSpawned()


### PR DESCRIPTION
When a strange fruit spawns, we would check a few more things now before notifying the user
- Have we been logged in longer than 5 minutes?
- Has it an hour since we got a random event?
- Are we within 15 seconds of an event window (the 5 minute intervals)?

The 3rd one will probably prevent the most unnecessary notifications from being seen by the user (especially at shooting stars where there are tons of events happening)