### PR TITLE
Returns Instant.now instead of null when old profiles are used

### DIFF
--- a/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsPlugin.java
+++ b/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsPlugin.java
@@ -211,7 +211,9 @@ public class RandomEventAnalyticsPlugin extends Plugin
 		RandomEventRecord record = localStorage.getMostRecentRandom();
 		if (record.spawnedTime < 0)
 		{
-			return null;
+			// This assumes the profile failed to load. eg. malformed data, old profile that never had a random spawn, etc.
+			// we'll reset the timer.
+			return Instant.now();
 		}
 
 		return Instant.ofEpochMilli(record.spawnedTime);


### PR DESCRIPTION
Potential fix for https://github.com/zmanowar/random-event-analytics/issues/22