### PR TITLE
Reworks overlay to only contain "Next Check" and "Earliest" timers

### DIFF
--- a/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsConfig.java
+++ b/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsConfig.java
@@ -16,13 +16,7 @@ public interface RandomEventAnalyticsConfig extends Config
 	String LAST_RANDOM_SPAWN_INSTANT = "lastRandomSpawnInstant";
 	String INTERVALS_SINCE_LAST_RANDOM = "intervalsSinceLastRandom";
 	String FIRST_LOGIN_INSTANT = "firstLoginInstant";
-	@ConfigSection(
-		name = "Countdown",
-		description = "Logged-in countdown configuration",
-		position = 1,
-		closedByDefault = false
-	)
-	String countdownSection = "countdown";
+
 	@ConfigSection(
 		name = "Logging Panel",
 		description = "Settings related to the logging panel",
@@ -30,37 +24,20 @@ public interface RandomEventAnalyticsConfig extends Config
 		closedByDefault = false
 	)
 	String loggingPanelSection = "loggingPanelSection";
+
 	@ConfigSection(
-		name = "Experimental",
-		description = "Experimental features. May have a negative impact on performance.",
-		position = 3,
-		closedByDefault = true
+		name = "Overlay",
+		description = "Settings related to the overlay",
+		position = 2,
+		closedByDefault = false
 	)
-	String experimentalSection = "experimental";
-
-
-//	@ConfigSection(
-//		name = "Notifications",
-//		description = "Notifications for Random Event timing & activity",
-//		position = 0,
-//		closedByDefault = true
-//	)
-//	String notificationSection = "notifications";
-
-	@ConfigItem(
-		keyName = "enableEstimation",
-		name = "Enable Estimation",
-		description = "Shows a 5 minute sliding timer for events."
-	)
-	default boolean enableEstimation()
-	{
-		return true;
-	}
+	String overlaySection = "overlaySection";
 
 	@ConfigItem(
 		keyName = "enableOverlay",
 		name = "Enable Overlay",
-		description = "Show the Random Events overlay."
+		description = "Show the Random Events overlay.",
+		section = overlaySection
 	)
 	default boolean enableOverlay()
 	{
@@ -68,15 +45,16 @@ public interface RandomEventAnalyticsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "enableConfigCountdown",
-		name = "Enable Countdown",
-		description = "Enables the time since last random countdown",
-		section = countdownSection
+		keyName = "enableOverlayBackground",
+		name = "Color Overlay Background",
+		description = "Color the overlay background based on the current spawn window state.",
+		section = overlaySection
 	)
-	default boolean enableConfigCountdown()
+	default boolean enableOverlayBackground()
 	{
 		return true;
 	}
+
 
 	@ConfigItem(
 		keyName = "logTimeFormat",
@@ -89,26 +67,75 @@ public interface RandomEventAnalyticsConfig extends Config
 		return TimeFormat.TIME_24H;
 	}
 
-	@Range(min = 1)
-	@ConfigItem(
-		keyName = "countdownMinutes",
-		name = "Countdown (Minutes)",
-		description = "Number of minutes the countdown should last",
-		section = countdownSection
-	)
-	default int countdownMinutes()
-	{
-		return 60;
-	}
+// Deprecated config options, may need to migrate old values if we need to re-use the same keys.
 
-	@ConfigItem(
-		keyName = "showDebug",
-		name = "Show Debug",
-		description = "Shows debug information in the overlay.",
-		section = experimentalSection
-	)
-	default boolean showDebug()
-	{
-		return false;
-	}
+
+//	@ConfigSection(
+//		name = "Countdown",
+//		description = "Logged-in countdown configuration",
+//		position = 1,
+//		closedByDefault = false
+//	)
+//	String countdownSection = "countdown";
+
+//	@ConfigSection(
+//		name = "Experimental",
+//		description = "Experimental features. May have a negative impact on performance.",
+//		position = 3,
+//		closedByDefault = true
+//	)
+//	String experimentalSection = "experimental";
+
+
+//	@ConfigSection(
+//		name = "Notifications",
+//		description = "Notifications for Random Event timing & activity",
+//		position = 0,
+//		closedByDefault = true
+//	)
+//	String notificationSection = "notifications";
+
+//	@ConfigItem(
+//		keyName = "enableEstimation",
+//		name = "Enable Estimation",
+//		description = "Shows a 5 minute sliding timer for events."
+//	)
+//	default boolean enableEstimation()
+//	{
+//		return true;
+//	}
+
+//	@ConfigItem(
+//		keyName = "enableConfigCountdown",
+//		name = "Enable Countdown",
+//		description = "Enables the time since last random countdown",
+//		section = countdownSection
+//	)
+//	default boolean enableConfigCountdown()
+//	{
+//		return true;
+//	}
+
+//	@Range(min = 1)
+//	@ConfigItem(
+//		keyName = "countdownMinutes",
+//		name = "Countdown (Minutes)",
+//		description = "Number of minutes the countdown should last",
+//		section = countdownSection
+//	)
+//	default int countdownMinutes()
+//	{
+//		return 60;
+//	}
+
+//	@ConfigItem(
+//		keyName = "showDebug",
+//		name = "Show Debug",
+//		description = "Shows debug information in the overlay.",
+//		section = experimentalSection
+//	)
+//	default boolean showDebug()
+//	{
+//		return false;
+//	}
 }

--- a/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsOverlay.java
+++ b/src/main/java/com/randomEventAnalytics/RandomEventAnalyticsOverlay.java
@@ -1,31 +1,33 @@
 package com.randomEventAnalytics;
 
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import javax.inject.Inject;
+import net.runelite.api.Client;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.ComponentConstants;
 import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 
 public class RandomEventAnalyticsOverlay extends Overlay
 {
-	private static final String EARLIEST_LABEL = "Earliest possible: ";
-	private static final String LATEST_LABEL = "Latest possible: ";
-	private static final String TITLE_LABEL = "Random Event";
+	private static final int BACKGROUND_ALPHA = 126;
+
 	private final RandomEventAnalyticsConfig config;
 	private final PanelComponent panelComponent = new PanelComponent();
 	private final TimeTracking timeTracking;
-	private final RandomEventAnalyticsPlugin plugin;
+	private final Client client;
 
 	@Inject
 	private RandomEventAnalyticsOverlay(RandomEventAnalyticsConfig config,
-										TimeTracking timeTracking, RandomEventAnalyticsPlugin plugin)
+										TimeTracking timeTracking, Client client)
 	{
 		setPosition(OverlayPosition.ABOVE_CHATBOX_RIGHT);
 		this.config = config;
 		this.timeTracking = timeTracking;
-		this.plugin = plugin;
+		this.client = client;
 	}
 
 	@Override
@@ -35,68 +37,54 @@ public class RandomEventAnalyticsOverlay extends Overlay
 		{
 			return null;
 		}
+
 		panelComponent.getChildren().clear();
+		panelComponent.setPreferredSize(new Dimension(ComponentConstants.STANDARD_WIDTH, 0));
 
-		if (config.enableEstimation())
+		final boolean hasAnchor = timeTracking.getWindowAnchor() != null;
+		final boolean windowExpired = timeTracking.isWindowExpired();
+		final boolean windowOpen = timeTracking.isWindowOpen();
+		final boolean inInstance = client.isInInstancedRegion();
+		final boolean noEventsYet = timeTracking.getLastRandomSpawnInstant() == null;
+		final WindowState windowState = WindowState.from(hasAnchor, windowExpired, windowOpen, inInstance,
+			noEventsYet);
+
+		if (config.enableOverlayBackground())
 		{
-			// 5-minute eligibility window countdown (existing behaviour).
-			int closestSpawnTimer = timeTracking.getNextRandomEventEstimation();
-			panelComponent.getChildren().add(LineComponent.builder()
-				.left(timeTracking.hasLoggedInLongEnoughForSpawn() ? "Eligible check in" : "Initial login...")
-				.right(RandomEventAnalyticsUtil.formatSeconds(Math.abs(closestSpawnTimer)))
-				.build());
+			final Color base = windowState.badgeColor;
+			panelComponent.setBackgroundColor(new Color(base.getRed(), base.getGreen(), base.getBlue(),
+				BACKGROUND_ALPHA));
+		}
+		else
+		{
+			panelComponent.setBackgroundColor(ComponentConstants.STANDARD_BACKGROUND_COLOR);
 		}
 
-		if (config.enableConfigCountdown())
+		// Tick line: 5-minute eligibility countdown.
+		final int nextTickSeconds = timeTracking.getNextRandomEventEstimation();
+		panelComponent.getChildren().add(LineComponent.builder()
+			.left("Next Check:")
+			.right(RandomEventAnalyticsUtil.formatSeconds(Math.abs(nextTickSeconds)))
+			.build());
+
+		// Earliest line: countdown to the spawn window opening.
+		final String earliestText;
+		if (windowExpired)
 		{
-			boolean windowExpired = timeTracking.isWindowExpired();
-			boolean windowOpen = timeTracking.isWindowOpen();
-
-			if (windowExpired)
-			{
-				String status = timeTracking.isOfflineExtensionLikely() ? "Offline ext. possible" : "Window passed";
-				panelComponent.getChildren().add(LineComponent.builder()
-					.left(EARLIEST_LABEL)
-					.right("Overdue \u2014 " + status)
-					.build());
-			}
-			else if (windowOpen)
-			{
-				panelComponent.getChildren().add(LineComponent.builder()
-					.left(EARLIEST_LABEL)
-					.right("Now")
-					.build());
-				panelComponent.getChildren().add(LineComponent.builder()
-					.left(LATEST_LABEL)
-					.right(RandomEventAnalyticsUtil.formatSeconds((int) timeTracking.getSecondsUntilLatest()))
-					.build());
-			}
-			else
-			{
-				boolean noEventsYet = timeTracking.getLastRandomSpawnInstant() == null;
-				panelComponent.getChildren().add(LineComponent.builder()
-					.left(noEventsYet ? "Earliest (est.): " : EARLIEST_LABEL)
-					.right(RandomEventAnalyticsUtil.formatSeconds((int) timeTracking.getSecondsUntilEarliest()))
-					.build());
-				panelComponent.getChildren().add(LineComponent.builder()
-					.left(noEventsYet ? "Latest (est.): " : LATEST_LABEL)
-					.right(RandomEventAnalyticsUtil.formatSeconds((int) timeTracking.getSecondsUntilLatest()))
-					.build());
-			}
+			earliestText = "overdue";
 		}
-
-		if (config.showDebug())
+		else if (windowOpen)
 		{
-			panelComponent.getChildren().add(LineComponent.builder()
-				.left("Ticks: ")
-				.right(String.valueOf(timeTracking.getTicksSinceLastRandomEvent()))
-				.build());
-
-			panelComponent.getChildren().add(LineComponent.builder()
-				.left("# of Events Logged: ")
-				.right(String.valueOf(plugin.getNumberOfEventsLogged()))
-				.build());
+			earliestText = "now";
 		}
+		else
+		{
+			earliestText = RandomEventAnalyticsUtil.formatSeconds((int) timeTracking.getSecondsUntilEarliest());
+		}
+		panelComponent.getChildren().add(LineComponent.builder()
+			.left("Earliest:")
+			.right(earliestText)
+			.build());
 
 		return panelComponent.render(graphics);
 	}


### PR DESCRIPTION
Based on feedback from issue #31.

- Overlay renders 2 text lines for tracking the next 5-min tick and the next earliest spawn.
- The background color of the overlay represents the status of the spawn window (waiting, eligible, etc).
  - This may be disabled via config.
- Deprecates old config toggles.